### PR TITLE
ubuntu/debian packaging fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,8 @@ project(pvr.zattoo)
 cmake_minimum_required(VERSION 2.8.12)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
-set(PC_RapidJSON_INCLUDEDIR ${PROJECT_SOURCE_DIR}/depends/target/rapidjson/native/build/dummy/include)
 
 enable_language(CXX)
-
-execute_process(
-	COMMAND make PREFIX=dummy
-	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/depends/target/rapidjson/
-)
 
 find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
+find_package(PkgConfig)
 find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)

--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,8 @@
 Source: kodi-pvr-zattoo
 Priority: extra
 Maintainer: rbuehlma <rene@buehlmann.net>
-Build-Depends: debhelper (>= 9.0.0), cmake, libkodiplatform-dev (>= 16.0.0),
-               kodi-addon-dev, zlib1g-dev
+Build-Depends: debhelper (>= 9.0.0), cmake, libkodiplatform-dev (>= 17.1),
+               kodi-addon-dev, rapidjson-dev, libp8-platform-dev
 Standards-Version: 3.9.4
 Section: libs
 Homepage: http://kodi.tv

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="pvr.zattoo" version="18.0.14" name="Zattoo PVR Client" provider-name="trummerjo,rbuehlma">
+<addon id="pvr.zattoo"
+       version="18.0.14"
+       name="Zattoo PVR Client"
+       provider-name="trummerjo,rbuehlma">
   <requires>@ADDON_DEPENDS@</requires>
   <extension point="xbmc.pvrclient" library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
fixes for packaging on ubuntu and debian.

additional note, independent from this PR: tinyxml2 shouldn't be included, but moved to a dependency