### PR TITLE
cmake: add ZATTOO_HEADERS; reduces build time drastically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,18 @@ set(ZATTOO_SOURCES
 		src/md5.cpp
 )
 
+set(ZATTOO_HEADERS
+		src/Cache.h
+		src/Curl.h
+		src/UpdateThread.h
+		src/Utils.h
+		src/ZatData.h
+		src/categories.h
+		src/client.h
+		src/md5.h
+		src/to_string.h
+)
+
 if(WIN32)
 	list(APPEND DEPLIBS ws2_32)
 endif()


### PR DESCRIPTION
Before: build time on my machine 1 min 16 sec

<pre>
Force build of pvr.zattoo
[ 82%] Performing build step for 'pvr.zattoo'
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE) 
-- RapidJSON found. Headers: /Users/kai/src/github/ksooo/pvr.zattoo/build/build/depends/include
-- ZATTOO_VERSION=18.0.42
-- ZATTOO_VERSION=18.0.42
CMake Warning (dev) at build/build/depends/lib/kodi/AddonHelpers.cmake:77 (message):
  Header files not defined in your CMakeLists.txt.  Please consider defining
  ZATTOO_HEADERS as list of all headers used by this addon.  Falling back to
  recursive scan for *.h.
Call Stack (most recent call first):
  CMakeLists.txt:47 (build_addon)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Added usage definition: ADDON_GLOBAL_VERSION_MAIN_USED
-- Added usage definition: ADDON_GLOBAL_VERSION_GUI_USED
-- Added usage definition: ADDON_GLOBAL_VERSION_FILESYSTEM_USED
-- Added usage definition: ADDON_INSTANCE_VERSION_GAME_USED
-- Added usage definition: ADDON_INSTANCE_VERSION_PVR_USED
-- Added usage definition: ADDON_INSTANCE_VERSION_VIDEOCODEC_USED
-- Configuring done</pre>

After: build time on same machine 0 min 10 sec

<pre>
Force build of pvr.zattoo
[ 82%] Performing build step for 'pvr.zattoo'
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE) 
-- RapidJSON found. Headers: /Users/kai/src/github/ksooo/pvr.zattoo/build/build/depends/include
-- ZATTOO_VERSION=18.0.42
-- ZATTOO_VERSION=18.0.42
-- Added usage definition: ADDON_GLOBAL_VERSION_MAIN_USED
-- Added usage definition: ADDON_GLOBAL_VERSION_GUI_USED
-- Added usage definition: ADDON_INSTANCE_VERSION_PVR_USED
-- Configuring done
</pre>

Reason: recursive scan for *.h is really very time consuming.