### PR TITLE
[pvr.zattoo] bump to 19.1.0

### DIFF
--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.zattoo"
-       version="19.0.4"
+       version="19.1.0"
        name="Zattoo PVR Client"
        provider-name="trummerjo,rbuehlma">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.zattoo/changelog.txt
+++ b/pvr.zattoo/changelog.txt
@@ -1,3 +1,5 @@
+v19.1.0
+ - Update to GUI addon API v5.14.0
 v19.0.4
  - Fallback to country code if service region country is missing
 v19.0.3


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required

(only merge once the mentioned PR is merged)