### PR TITLE
Change version to 19.2.1 related to Kodi API update and build changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       sudo: required
       compiler: clang
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode10.2
 
 #
 # The addon source is automatically checked out in $TRAVIS_BUILD_DIR,

--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.zattoo"
-       version="19.2.0"
+       version="19.2.1"
        name="Zattoo PVR Client"
        provider-name="trummerjo,rbuehlma">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.zattoo/changelog.txt
+++ b/pvr.zattoo/changelog.txt
@@ -1,3 +1,5 @@
+v19.2.1
+ - Update cmake build system to Version 3.5
 v19.2.0
  - Recompile for 6.1.0 PVR Addon API compatibility
 v19.1.0


### PR DESCRIPTION
This addon use kodi_vfs_types.h where was changed from Kodi. This
increase version a bit to prevent problems.
Is related to xbmc/xbmc#16431 and xbmc/xbmc#16452

Further is the used cmake Version changed to 3.5 to have equal with minimal
needed version of Kodi.

Also is the osx_image on travis changed to xcode10.2 to have equal with Kodi.

As question, does it make sense to add "appveyor.yml" here as well?