### PR TITLE
Fully implement IsRealTimeStream()

### DIFF
--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.zattoo"
-       version="19.2.20"
+       version="19.2.21"
        name="Zattoo PVR Client"
        provider-name="trummerjo,rbuehlma">
   <requires>
@@ -32,6 +32,8 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v19.2.21
+ - Fully implement IsRealtimeStream()
 v19.2.20
  - Update PVR API 6.5.0
 v19.2.19

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -40,6 +40,7 @@ std::string parentalPin;
 std::string xmlTVFile;
 int provider = 0;
 int runningRequests = 0;
+bool isLivePlayback = false;
 
 extern "C"
 {
@@ -474,6 +475,7 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel,
     setStreamProperties(properties, propertiesCount, strUrl, additionalProperties);
     setStreamProperty(properties, propertiesCount, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = true;
   }
   runningRequests--;
   return ret;
@@ -491,6 +493,7 @@ PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording,
     *propertiesCount = 0;
     setStreamProperties(properties, propertiesCount, strUrl, additionalProperties);
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = false;
   }
   runningRequests--;
   return ret;
@@ -675,6 +678,7 @@ PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG* tag,
     *iPropertiesCount = 0;
     setStreamProperties(properties, iPropertiesCount, strUrl, additionalProperties);
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = false;
   }
   runningRequests--;
   return ret;
@@ -831,7 +835,7 @@ unsigned int GetChannelSwitchDelay(void)
 }
 bool IsRealTimeStream(void)
 {
-  return true;
+  return isLivePlayback;
 }
 void PauseStream(bool bPaused)
 {


### PR DESCRIPTION
19.2.21
 - Fully implement IsRealtimeStream()

Can be merged once you are happy with the change and CI passes.

The change is related to a change in kodi whereby this function can be called when playing back a recording. If not correctly set the fast forward/rewind buttons can be missing.