### PR TITLE
Remove p8 from debian control file - v19.4.3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-zattoo
 Priority: extra
 Maintainer: rbuehlma <rene@buehlmann.net>
-Build-Depends: debhelper (>= 9.0.0), cmake, pkg-config, libkodiplatform-dev (>= 17.1),
+Build-Depends: debhelper (>= 9.0.0), cmake, pkg-config,
                kodi-addon-dev, rapidjson-dev, libp8-platform-dev, libtinyxml2-dev
 Standards-Version: 4.1.2
 Section: libs

--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.zattoo"
-       version="19.4.2"
+       version="19.4.3"
        name="Zattoo PVR Client"
        provider-name="trummerjo,rbuehlma">
   <requires>
@@ -32,6 +32,8 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v19.4.3
+- Remove p8 from debian control file
 v19.4.2
  - Remove p8-platform dependency
  - Use std::thread


### PR DESCRIPTION
v19.4.3
- Remove p8 from debian control file