### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.zattoo"
-       version="20.0.0"
+       version="20.1.0"
        name="Zattoo PVR Client"
        provider-name="trummerjo,rbuehlma">
   <requires>
@@ -32,6 +32,10 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v20.1.0
+- Kodi PVR API to 8.0.0
+  - Add supports recordings delete capability
+  - Enforce EDL limits
 v20.0.0
  - Fix some compile warnings by depends build of rapidjson
  - Cleanup language texts in strings.po and addon.xml

--- a/src/ZatData.cpp
+++ b/src/ZatData.cpp
@@ -509,6 +509,7 @@ PVR_ERROR ZatData::GetCapabilities(kodi::addon::PVRCapabilities& capabilities)
   capabilities.SetSupportsDescrambleInfo(false);
   capabilities.SetSupportsRecordingEdl(true);
   capabilities.SetSupportsRecordings(m_recordingEnabled);
+  capabilities.SetSupportsRecordingsDelete(m_recordingEnabled);
   capabilities.SetSupportsTimers(m_recordingEnabled);
 
   return PVR_ERROR_NO_ERROR;


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Following in API change (not all affect addon):
    - Add supports recordings delete capability
    - Add support for PVR Providers and parental rating code for EPG
    - Enforce EDL limits

**WARNING:** Merge after the requests on Kodi are in.

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395