### PR TITLE
GetRecordingEdl, to play recording 5 minutes in.

### DIFF
--- a/src/ZatData.cpp
+++ b/src/ZatData.cpp
@@ -1380,6 +1380,16 @@ PVR_ERROR ZatData::GetEPGTagEdl(const kodi::addon::PVREPGTag& tag, std::vector<k
   return PVR_ERROR_NO_ERROR;
 }
 
+PVR_ERROR ZatData::GetRecordingEdl(const kodi::addon::PVRRecording& recording, std::vector<kodi::addon::PVREDLEntry>& edl)
+{
+  kodi::addon::PVREDLEntry entry;
+  entry.SetStart(0);
+  entry.SetEnd(300000);
+  entry.SetType(PVR_EDL_TYPE_COMBREAK);
+  edl.emplace_back(entry);
+  return PVR_ERROR_NO_ERROR;
+}
+
 bool ZatData::TryToReinitIf403(int statusCode) {
   if (statusCode == 403)
   {

--- a/src/ZatData.h
+++ b/src/ZatData.h
@@ -69,6 +69,7 @@ public:
   PVR_ERROR IsEPGTagRecordable(const kodi::addon::PVREPGTag& tag, bool& isRecordable) override;
   PVR_ERROR GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& tag, std::vector<kodi::addon::PVRStreamProperty>& properties) override;
   PVR_ERROR GetEPGTagEdl(const kodi::addon::PVREPGTag& tag, std::vector<kodi::addon::PVREDLEntry>& edl) override;
+  PVR_ERROR GetRecordingEdl(const kodi::addon::PVRRecording& recording, std::vector<kodi::addon::PVREDLEntry>& edl) override;  
 
   int GetRecallSeconds(const kodi::addon::PVREPGTag& tag);
   void GetEPGForChannelAsync(int uniqueChannelId, time_t iStart, time_t iEnd);


### PR DESCRIPTION
Same as catchup from EPG.
5 minutes EDL was missing when launching recorded stream vs launch from EPG.
 