### PR TITLE
Add Galaxus TV

### DIFF
--- a/pvr.zattoo/resources/language/resource.language.de_de/strings.po
+++ b/pvr.zattoo/resources/language/resource.language.de_de/strings.po
@@ -198,6 +198,12 @@ msgctxt "#30116"
 msgid "1&1 TV"
 msgstr "1&1 TV"
 
+#. Selection value for setting defined with id #30099
+#: pvr.zattoo/resources/settings.xml
+msgctxt "#30117"
+msgid "Galaxus TV"
+msgstr "Galaxus TV"
+
 #. Notification message to show on screen if username or password not set
 #: src/client.cpp
 msgctxt "#30200"

--- a/pvr.zattoo/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.zattoo/resources/language/resource.language.en_gb/strings.po
@@ -206,6 +206,12 @@ msgctxt "#30116"
 msgid "1&1 TV"
 msgstr ""
 
+#. Selection value for setting defined with id #30099
+#: pvr.zattoo/resources/settings.xml
+msgctxt "#30117"
+msgid "Galaxus TV"
+msgstr "Galaxus TV"
+
 #. Notification message to show on screen if username or password not set
 #: src/client.cpp
 msgctxt "#30200"

--- a/pvr.zattoo/resources/settings.xml
+++ b/pvr.zattoo/resources/settings.xml
@@ -73,6 +73,7 @@
               <option label="30114">14</option> <!-- Salt.ch -->
               <option label="30115">15</option> <!-- swb TV -->
               <option label="30116">16</option> <!-- 1&1 TV -->
+              <option label="30117">17</option> <!-- Galaxus TV -->
             </options>
           </constraints>
           <control type="list" format="integer" />

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -325,6 +325,9 @@ void Session::SetProviderUrl() {
     case 16:
       m_providerUrl = "https://www.1und1.tv";
       break;
+    case 17:
+      m_providerUrl = "https://tv.galaxus.ch";
+      break;
     default:
       m_providerUrl = "https://zattoo.com";
     }


### PR DESCRIPTION
Hi rbuehlma

Galaxus started a Zattoo based TV service a last week. I wanted to try it using this addon and added the respective settings and URLs. As far as I could test on a OSMC (Kodi) box it basically works when not enabling the "Smart TV" option.

Pls reach out to me, if I forgot something.

Best Regards and thanks a lot for providing this addon!
Luc